### PR TITLE
Add extended benchmarks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             pydocstyle,
             Pygments,
         ]
-        args: [--ignore, "N806, D404, D100, D103"]
+        args: [--ignore, "N806, D404, D100, D103, E800", --docstring-convention, "google"]
 -   repo: https://github.com/guilatrova/tryceratops
     rev: v1.0.1
     hooks:

--- a/src/tranquilo_dev/benchmarks/benchmark_problems.py
+++ b/src/tranquilo_dev/benchmarks/benchmark_problems.py
@@ -3,32 +3,46 @@ from collections import ChainMap
 import estimagic as em
 import numpy as np
 from pybaum import tree_update
-from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
-from tranquilo_dev.config import PROBLEM_SETS
 
 
-def get_benchmark_problems(problem_name):
-    problem_kwargs = PROBLEM_SETS[problem_name]
-    problems = em.get_benchmark_problems(**problem_kwargs)
+DEFAULT_SAMPLE_KWARGS = {
+    "minimal_radius": 0.1,
+    "percentage_deviation_radius": 0.01,
+}
 
-    if BENCHMARK_PROBLEMS_INFO["n_draws"] > 0:
 
-        new_problems = _draw_new_problems(
+def get_extended_benchmark_problems(
+    n_draws=0, seed=None, benchmark_kwargs=None, sample_kwargs=None
+):
+    # Process kwargs that are passed to em.get_benchmark_problems and get base problems
+    benchmark_kwargs = {} if benchmark_kwargs is None else benchmark_kwargs
+    problems = em.get_benchmark_problems(**benchmark_kwargs)
+
+    # Process kwargs that are used to for the random sampling
+    if isinstance(sample_kwargs, dict):
+        sample_kwargs = tree_update(DEFAULT_SAMPLE_KWARGS, sample_kwargs)
+    else:
+        sample_kwargs = DEFAULT_SAMPLE_KWARGS
+
+    # Sample new problems
+    if n_draws > 0:
+        new_problems = _sample_new_problems(
             problems=problems,
-            n_draws=BENCHMARK_PROBLEMS_INFO["n_draws"],
-            seed=BENCHMARK_PROBLEMS_INFO["seed"],
+            n_draws=n_draws,
+            seed=seed,
+            sample_kwargs=sample_kwargs,
         )
-
     else:
         new_problems = {}
 
     return {**problems, **new_problems}
 
 
-def _draw_new_problems(
+def _sample_new_problems(
     problems: dict,
     n_draws: int,
     seed: int,
+    sample_kwargs: dict[str, float],
 ) -> dict:
     rng = np.random.default_rng(seed)
 
@@ -40,6 +54,7 @@ def _draw_new_problems(
             problem_name=problem_name,
             problem=problem,
             n_draws=n_draws,
+            sample_kwargs=sample_kwargs,
             rng=rng,
         )
 
@@ -50,12 +65,18 @@ def _draw_new_problems(
 
 
 def _generate_new_problems(
-    problem_name: str, problem: dict, n_draws: int, rng: np.random.Generator
+    problem_name: str,
+    problem: dict,
+    n_draws: int,
+    sample_kwargs: dict[str, float],
+    rng: np.random.Generator,
 ) -> dict:
-    new_start_vectors = _generate_new_start_vectors(
+    new_start_vectors = _draw_new_start_vectors(
+        problem_name=problem_name,
         problem=problem,
         n_draws=n_draws,
         rng=rng,
+        **sample_kwargs,
     )
 
     new_problems = {}
@@ -67,29 +88,107 @@ def _generate_new_problems(
     return new_problems
 
 
+def _draw_new_start_vectors(
+    problem_name: str,
+    problem: dict,
+    n_draws: int,
+    rng: np.random.Generator,
+    minimal_radius: float,
+    percentage_deviation_radius: float,
+) -> list[np.ndarray]:
+    new_start_vectors = []
+
+    for _ in range(n_draws):
+
+        new_start_vector = _draw_single_new_start_vector(
+            problem_name=problem_name,
+            problem=problem,
+            rng=rng,
+            percentage_deviation_radius=percentage_deviation_radius,
+            minimal_radius=minimal_radius,
+        )
+        new_start_vectors.append(new_start_vector)
+
+    return new_start_vectors
+
+
+def _draw_single_new_start_vector(
+    problem_name: str,
+    problem: dict,
+    rng: np.random.Generator,
+    percentage_deviation_radius: float,
+    minimal_radius: float,
+) -> np.ndarray:
+    """Draw a new start vector for a given problem.
+
+    Args:
+        problem_name (str): The name of the problem.
+        problem (dict): The problem dictionary.
+        rng (np.random.Generator): A random number generator
+        percentage_deviation_radius (float): The percentage deviation from x.
+        minimal_radius (float): The minimal radius in each direction.
+
+    Returns:
+        np.ndarray: The new start vector.
+
+    """
+    x = problem["inputs"]["params"]
+    criterion = problem["inputs"]["criterion"]
+
+    radius = _calculate_radius(
+        x,
+        percentage_deviation=percentage_deviation_radius,
+        minimal_radius=minimal_radius,
+    )
+
+    success = False
+
+    for _ in range(100):
+        candidate = rng.uniform(low=x - radius, high=x + radius)
+
+        # Verify that the criterion function is well-defined at the candidate x-value,
+        # and otherwise reduce the radius by half.
+        try:
+            _value = criterion(candidate)
+            value = _value["value"] if isinstance(_value, dict) else _value
+            assert np.isfinite(value)
+        except Exception:
+            radius /= 2
+        else:
+            success = True
+            break
+
+    if not success:
+        raise RuntimeError(
+            f"Could not find a valid new starting vector for {problem_name}."
+        )
+
+    return candidate
+
+
+def _calculate_radius(
+    x: np.ndarray,
+    percentage_deviation: float,
+    minimal_radius: float,
+) -> np.ndarray:
+    """Calculate the radius of a box around x.
+
+    Args:
+        x (np.ndarray): The center of the box.
+        percentage_deviation (float): The percentage deviation from x. If x1 is 10 and
+            percentage_deviation is 0.1, then the radius is 1 in the first direction.
+        minimal_radius (float): The minimal radius in each direction.
+
+    Returns:
+        np.ndarray: The radius of the box.
+
+    """
+    candidate = percentage_deviation * np.abs(x)
+    return np.clip(candidate, a_min=minimal_radius, a_max=None)
+
+
 def _update_start_vector_in_problem(
     problem: dict, new_start_vector: np.ndarray
 ) -> dict:
     update_dict = {"inputs": {"params": new_start_vector}}
     return tree_update(problem, update_dict)
-
-
-def _generate_new_start_vectors(
-    problem: dict,
-    n_draws: int,
-    rng: np.random.Generator,
-) -> np.ndarray:
-    x = problem["inputs"]["params"]
-
-    radius = _calculate_radius(x)
-    lower = x - radius
-    upper = x + radius
-
-    return rng.uniform(low=lower, high=upper, size=(n_draws, len(x)))
-
-
-def _calculate_radius(
-    x: np.ndarray, percentage_deviation: float = 0.1, minimal_radius: float = 0.1
-) -> np.ndarray:
-    candidate = percentage_deviation * np.abs(x)
-    return np.clip(candidate, a_min=minimal_radius, a_max=None)

--- a/src/tranquilo_dev/benchmarks/benchmark_problems.py
+++ b/src/tranquilo_dev/benchmarks/benchmark_problems.py
@@ -1,0 +1,95 @@
+from collections import ChainMap
+
+import estimagic as em
+import numpy as np
+from pybaum import tree_update
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
+from tranquilo_dev.config import PROBLEM_SETS
+
+
+def get_benchmark_problems(problem_name):
+    problem_kwargs = PROBLEM_SETS[problem_name]
+    problems = em.get_benchmark_problems(**problem_kwargs)
+
+    if BENCHMARK_PROBLEMS_INFO["n_draws"] > 0:
+
+        new_problems = _draw_new_problems(
+            problems=problems,
+            n_draws=BENCHMARK_PROBLEMS_INFO["n_draws"],
+            seed=BENCHMARK_PROBLEMS_INFO["seed"],
+        )
+
+    else:
+        new_problems = {}
+
+    return {**problems, **new_problems}
+
+
+def _draw_new_problems(
+    problems: dict,
+    n_draws: int,
+    seed: int,
+) -> dict:
+    rng = np.random.default_rng(seed)
+
+    list_of_new_problems = []
+
+    for problem_name, problem in problems.items():
+
+        _new_problems = _generate_new_problems(
+            problem_name=problem_name,
+            problem=problem,
+            n_draws=n_draws,
+            rng=rng,
+        )
+
+        list_of_new_problems.append(_new_problems)
+
+    # Merge list of dictionaries into one dictionary and return
+    return dict(ChainMap(*list_of_new_problems))
+
+
+def _generate_new_problems(
+    problem_name: str, problem: dict, n_draws: int, rng: np.random.Generator
+) -> dict:
+    new_start_vectors = _generate_new_start_vectors(
+        problem=problem,
+        n_draws=n_draws,
+        rng=rng,
+    )
+
+    new_problems = {}
+    for k, new_start_vector in enumerate(new_start_vectors):
+        new_problem = _update_start_vector_in_problem(problem, new_start_vector)
+        new_name = f"{problem_name}__draw_{k}"
+        new_problems[new_name] = new_problem
+
+    return new_problems
+
+
+def _update_start_vector_in_problem(
+    problem: dict, new_start_vector: np.ndarray
+) -> dict:
+    update_dict = {"inputs": {"params": new_start_vector}}
+    return tree_update(problem, update_dict)
+
+
+def _generate_new_start_vectors(
+    problem: dict,
+    n_draws: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    x = problem["inputs"]["params"]
+
+    radius = _calculate_radius(x)
+    lower = x - radius
+    upper = x + radius
+
+    return rng.uniform(low=lower, high=upper, size=(n_draws, len(x)))
+
+
+def _calculate_radius(
+    x: np.ndarray, percentage_deviation: float = 0.1, minimal_radius: float = 0.1
+) -> np.ndarray:
+    candidate = percentage_deviation * np.abs(x)
+    return np.clip(candidate, a_min=minimal_radius, a_max=None)

--- a/src/tranquilo_dev/benchmarks/benchmark_problems.py
+++ b/src/tranquilo_dev/benchmarks/benchmark_problems.py
@@ -7,8 +7,10 @@ from pybaum import tree_update
 
 
 class SampleOptions(NamedTuple):
+    """Options for the random sampling of new problems."""
+
     minimal_radius: float = 0.1
-    percentage_deviation_radius: float = 0.01
+    percentage_deviation_radius: float = 0.1
 
 
 def get_extended_benchmark_problems(

--- a/src/tranquilo_dev/benchmarks/task_run_competition.py
+++ b/src/tranquilo_dev/benchmarks/task_run_competition.py
@@ -1,20 +1,19 @@
 import estimagic as em
 import pandas as pd
 import pytask
+from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPETITION
 from tranquilo_dev.config import COMPETITION_CASES
 from tranquilo_dev.config import get_max_criterion_evaluations
 from tranquilo_dev.config import N_CORES
-from tranquilo_dev.config import PROBLEM_SETS
 
 
 OUT = BLD / "benchmarks"
 
 for problem_name, scenario_name in COMPETITION_CASES:
     noisy = "noisy" in problem_name
-    problem_kwargs = PROBLEM_SETS[problem_name]
-    problems = em.get_benchmark_problems(**problem_kwargs)
+    problems = get_benchmark_problems(problem_name)
     optimize_options = COMPETITION[scenario_name]
 
     name = f"{problem_name}_{scenario_name}"

--- a/src/tranquilo_dev/benchmarks/task_run_competition.py
+++ b/src/tranquilo_dev/benchmarks/task_run_competition.py
@@ -1,19 +1,23 @@
 import estimagic as em
 import pandas as pd
 import pytask
-from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPETITION
 from tranquilo_dev.config import COMPETITION_CASES
 from tranquilo_dev.config import get_max_criterion_evaluations
 from tranquilo_dev.config import N_CORES
+from tranquilo_dev.config import PROBLEM_SETS
 
 
 OUT = BLD / "benchmarks"
 
 for problem_name, scenario_name in COMPETITION_CASES:
     noisy = "noisy" in problem_name
-    problems = get_benchmark_problems(problem_name)
+    problems = get_extended_benchmark_problems(
+        benchmark_kwargs=PROBLEM_SETS[problem_name], **BENCHMARK_PROBLEMS_INFO
+    )
     optimize_options = COMPETITION[scenario_name]
 
     name = f"{problem_name}_{scenario_name}"

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_default.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_default.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
-from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
 from tranquilo_dev.config import get_max_criterion_evaluations
@@ -41,7 +42,9 @@ for functype in ["scalar", "ls"]:
                     }
                 )
 
-            problems = get_benchmark_problems(problem_name)
+            problems = get_extended_benchmark_problems(
+                benchmark_kwargs=PROBLEM_SETS[problem_name], **BENCHMARK_PROBLEMS_INFO
+            )
 
             name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_default.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_default.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
+from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
@@ -17,7 +18,7 @@ from tranquilo_dev.config import TRANQUILO_CASES
 OUT = BLD / "benchmarks"
 
 for functype in ["scalar", "ls"]:
-    for problem_name, problem_kwargs in PROBLEM_SETS.items():
+    for problem_name in PROBLEM_SETS:
         algorithm = get_tranquilo_version(functype)
         scenario_name = f"{algorithm}_default"
         noisy = "noisy" in problem_name
@@ -40,7 +41,7 @@ for functype in ["scalar", "ls"]:
                     }
                 )
 
-            problems = em.get_benchmark_problems(**problem_kwargs)
+            problems = get_benchmark_problems(problem_name)
 
             name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_experimental.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_experimental.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
+from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
@@ -17,7 +18,7 @@ from tranquilo_dev.config import TRANQUILO_CASES
 OUT = BLD / "benchmarks"
 
 for functype in ["scalar", "ls"]:
-    for problem_name, problem_kwargs in PROBLEM_SETS.items():
+    for problem_name in PROBLEM_SETS:
         algorithm = get_tranquilo_version(functype)
         scenario_name = f"{algorithm}_experimental"
         noisy = "noisy" in problem_name
@@ -40,7 +41,7 @@ for functype in ["scalar", "ls"]:
                     }
                 )
 
-            problems = em.get_benchmark_problems(**problem_kwargs)
+            problems = get_benchmark_problems(problem_name)
 
             name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_experimental.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_experimental.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
-from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
 from tranquilo_dev.config import get_max_criterion_evaluations
@@ -41,7 +42,9 @@ for functype in ["scalar", "ls"]:
                     }
                 )
 
-            problems = get_benchmark_problems(problem_name)
+            problems = get_extended_benchmark_problems(
+                benchmark_kwargs=PROBLEM_SETS[problem_name], **BENCHMARK_PROBLEMS_INFO
+            )
 
             name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
+from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
@@ -20,7 +21,7 @@ for batch_size in [2, 4, 8]:
 
     for functype in ["ls"]:
 
-        for problem_name, problem_kwargs in PROBLEM_SETS.items():
+        for problem_name in PROBLEM_SETS:
             algorithm = get_tranquilo_version(functype)
             scenario_name = f"{algorithm}_parallel_{batch_size}"
             max_iterations = get_max_iterations(noisy=False, functype=functype)
@@ -38,7 +39,7 @@ for batch_size in [2, 4, 8]:
                     "batch_size": batch_size,
                 }
 
-                problems = em.get_benchmark_problems(**problem_kwargs)
+                problems = get_benchmark_problems(problem_name)
 
                 name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
@@ -61,7 +61,6 @@ for batch_size in [2, 4, 8]:
                         n_cores=N_CORES,
                         max_criterion_evaluations=max_evals,  # noqa: B023
                         disable_convergence=False,
-                        error_handling="raise",
                     )
 
                     if COMPAT_MODE:

--- a/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
+++ b/src/tranquilo_dev/benchmarks/task_run_tranquilo_parallel.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 import estimagic as em
 import pytask
-from tranquilo_dev.benchmarks.benchmark_problems import get_benchmark_problems
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
 from tranquilo_dev.benchmarks.compat_mode import filter_tranquilo_benchmark
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import COMPAT_MODE
 from tranquilo_dev.config import get_max_criterion_evaluations
@@ -39,7 +40,10 @@ for batch_size in [2, 4, 8]:
                     "batch_size": batch_size,
                 }
 
-                problems = get_benchmark_problems(problem_name)
+                problems = get_extended_benchmark_problems(
+                    benchmark_kwargs=PROBLEM_SETS[problem_name],
+                    **BENCHMARK_PROBLEMS_INFO,
+                )
 
                 name = f"{problem_name}_{scenario_name}"
 

--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -45,7 +45,7 @@ def get_tranquilo_version(functype):
     return "tranquilo" if functype == "scalar" else "tranquilo_ls"
 
 
-N_CORES = 10
+N_CORES = 16
 
 PROBLEM_SETS = {
     "mw": {
@@ -180,7 +180,7 @@ _deterministic_plots = {
         "problem_name": "mw",
         "scenarios": [
             "tranquilo_ls_default",
-            "tranquilo_ls_experimental",
+            # "tranquilo_ls_experimental",
             "dfols",
         ],
         "profile_plot_options": {
@@ -284,26 +284,26 @@ _deterministic_plots = {
 }
 
 _noisy_plots = {
-    "competition_scalar_noisy": {
-        "problem_name": "mw_noisy",
-        "scenarios": [
-            "tranquilo_default",
-            "tranquilo_experimental",
-            "nag_bobyqa_noisy_5",
-        ],
-        "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
-        "convergence_plot_options": {"n_cols": 6},
-    },
-    "competition_ls_noisy": {
-        "problem_name": "mw_noisy",
-        "scenarios": [
-            "tranquilo_ls_default",
-            "tranquilo_ls_experimental",
-            "dfols_noisy_5",
-        ],
-        "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
-        "convergence_plot_options": {"n_cols": 6},
-    },
+    # "competition_scalar_noisy": {
+    #     "problem_name": "mw_noisy",
+    #     "scenarios": [
+    #         "tranquilo_default",
+    #         "tranquilo_experimental",
+    #         "nag_bobyqa_noisy_5",
+    #     ],
+    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
+    #     "convergence_plot_options": {"n_cols": 6},
+    # },
+    # "competition_ls_noisy": {
+    #     "problem_name": "mw_noisy",
+    #     "scenarios": [
+    #         "tranquilo_ls_default",
+    #         "tranquilo_ls_experimental",
+    #         "dfols_noisy_5",
+    #     ],
+    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
+    #     "convergence_plot_options": {"n_cols": 6},
+    # },
     "noisy_ls": {
         "problem_name": "mw_noisy",
         "scenarios": [

--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -6,6 +6,9 @@ PROBLEM_SETS: This is a dictionary that defines the problems that can be used in
 benchmarks. The keys are names, the values are dictionaries with keyword arguments for
 `em.get_benchmark_problems`.
 
+BENCHMARK_PROBLEMS_INFO: This is a dictionary that defines how many additional problems
+are generated for each problem in PROBLEM_SETS. The keys are "n_draws" and "seed".
+
 COMPETITION: This is a dictionary that defines the optimizer configurations against
 which we want to compare tranquilo. The keys are the names of the optimizer
 configurations, the values are dictionaries with keyword arguments for the minimization.
@@ -56,6 +59,16 @@ PROBLEM_SETS = {
         "additive_noise_options": {"distribution": "normal", "std": 1.2},
         "seed": 925408,
     },
+}
+
+
+BENCHMARK_PROBLEMS_INFO = {
+    # Number of additional draws per problem that are used to generate more problems.
+    # For each problems n_draws new start vectors are drawn in the vicinity of the
+    # original start vector, each defining a new problem.
+    "n_draws": 4,
+    # Random number generator seed used to control the random draws.
+    "seed": 440219,
 }
 
 

--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -291,7 +291,7 @@ _noisy_plots = {
     #         "tranquilo_experimental",
     #         "nag_bobyqa_noisy_5",
     #     ],
-    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
+    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},  # noqa: E501
     #     "convergence_plot_options": {"n_cols": 6},
     # },
     # "competition_ls_noisy": {
@@ -301,7 +301,7 @@ _noisy_plots = {
     #         "tranquilo_ls_experimental",
     #         "dfols_noisy_5",
     #     ],
-    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},
+    #     "profile_plot_options": {"y_precision": NOISY_Y_TOL, "normalize_runtime": True},  # noqa: E501
     #     "convergence_plot_options": {"n_cols": 6},
     # },
     "noisy_ls": {

--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -66,7 +66,7 @@ BENCHMARK_PROBLEMS_INFO = {
     # Number of additional draws per problem that are used to generate more problems.
     # For each problems n_draws new start vectors are drawn in the vicinity of the
     # original start vector, each defining a new problem.
-    "n_draws": 4,
+    "n_additional_draws": 4,
     # Random number generator seed used to control the random draws.
     "seed": 440219,
 }

--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -18,6 +18,7 @@ plotted against each other. Only combinations that are used in some plot will ac
 run.
 
 """
+import socket
 from pathlib import Path
 
 SRC = Path(__file__).parent.resolve()
@@ -45,7 +46,22 @@ def get_tranquilo_version(functype):
     return "tranquilo" if functype == "scalar" else "tranquilo_ls"
 
 
-N_CORES = 16
+def get_n_cores():
+    """Set the number of cores depending on the hostname."""
+    mapping = {
+        # Tim's thinkpad
+        "thinky": 16,
+        # Janos' thinkpad
+        "IZA-LAP479": 10,
+    }
+
+    hostname = socket.gethostname()
+
+    n_cores = mapping.get(hostname, 6)
+    return n_cores
+
+
+N_CORES = get_n_cores()
 
 PROBLEM_SETS = {
     "mw": {

--- a/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
+++ b/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
@@ -181,7 +181,7 @@ matplotlib.rcParams["font.family"] = "sans-serif"
 
 
 def plot_benchmark(data, plot, benchmark):
-    """Create the base matplotlib figure.  # noqa: D406, D407, D400
+    """Create the base matplotlib figure.
 
     Args:
         data (dict): Dictionary containing the data to plot. Keys represent a single

--- a/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
+++ b/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
@@ -38,7 +38,7 @@ X_RANGE = {
     "profile_plot": {
         "scalar_benchmark": (1, 50),
         "ls_benchmark": (1, 40),
-        "parallel_benchmark": (1,),
+        "parallel_benchmark": (1, 6),
         "noisy_benchmark": (1,),
         "scalar_vs_ls_benchmark": (1, 50),
     },

--- a/src/tranquilo_dev/plotting/task_create_benchmark_plots.py
+++ b/src/tranquilo_dev/plotting/task_create_benchmark_plots.py
@@ -1,12 +1,13 @@
 from copy import deepcopy
 
-import estimagic as em
 import pandas as pd
 import plotly.io as pio
 import pytask
 from estimagic import convergence_plot
 from estimagic import profile_plot
 from estimagic.visualization.deviation_plot import deviation_plot
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
+from tranquilo_dev.config import BENCHMARK_PROBLEMS_INFO
 from tranquilo_dev.config import BLD
 from tranquilo_dev.config import LABELS
 from tranquilo_dev.config import PLOT_CONFIG
@@ -97,7 +98,10 @@ for name, info in PLOT_CONFIG.items():
             for path in depends_on.values():
                 results = {**results, **pd.read_pickle(path)}
 
-            problems = em.get_benchmark_problems(**PROBLEM_SETS[info["problem_name"]])
+            problems = get_extended_benchmark_problems(
+                benchmark_kwargs=PROBLEM_SETS[info["problem_name"]],
+                **BENCHMARK_PROBLEMS_INFO,
+            )
 
             func_dict = {
                 "profile": profile_plot,

--- a/tests/test_benchmark_problems.py
+++ b/tests/test_benchmark_problems.py
@@ -5,11 +5,11 @@ from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_p
 def test_deterministic_property():
     """Test that the same seed leads to the same newly drawn start values."""
     p1 = get_extended_benchmark_problems(
-        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+        n_additional_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
     )
 
     p2 = get_extended_benchmark_problems(
-        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+        n_additional_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
     )
 
     v1 = {k: v["inputs"]["params"] for k, v in p1.items()}
@@ -21,11 +21,11 @@ def test_deterministic_property():
 def test_stochastic_property():
     """Test that different seeds lead to the different newly drawn start values."""
     p1 = get_extended_benchmark_problems(
-        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+        n_additional_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
     )
 
     p2 = get_extended_benchmark_problems(
-        n_draws=2, seed=54321, benchmark_kwargs={"name": "more_wild"}
+        n_additional_draws=2, seed=54321, benchmark_kwargs={"name": "more_wild"}
     )
 
     v1 = {k: v["inputs"]["params"] for k, v in p1.items()}

--- a/tests/test_benchmark_problems.py
+++ b/tests/test_benchmark_problems.py
@@ -1,0 +1,34 @@
+from pybaum import tree_equal
+from tranquilo_dev.benchmarks.benchmark_problems import get_extended_benchmark_problems
+
+
+def test_deterministic_property():
+    """Test that the same seed leads to the same newly drawn start values."""
+    p1 = get_extended_benchmark_problems(
+        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+    )
+
+    p2 = get_extended_benchmark_problems(
+        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+    )
+
+    v1 = {k: v["inputs"]["params"] for k, v in p1.items()}
+    v2 = {k: v["inputs"]["params"] for k, v in p2.items()}
+
+    assert tree_equal(v1, v2)
+
+
+def test_stochastic_property():
+    """Test that different seeds lead to the different newly drawn start values."""
+    p1 = get_extended_benchmark_problems(
+        n_draws=2, seed=12345, benchmark_kwargs={"name": "more_wild"}
+    )
+
+    p2 = get_extended_benchmark_problems(
+        n_draws=2, seed=54321, benchmark_kwargs={"name": "more_wild"}
+    )
+
+    v1 = {k: v["inputs"]["params"] for k, v in p1.items()}
+    v2 = {k: v["inputs"]["params"] for k, v in p2.items()}
+
+    assert not tree_equal(v1, v2)


### PR DESCRIPTION
In this PR, we add functionality to extend the base benchmarks set provided by `estimagic.get_benchmark_problems`.

### Final Check
- [x] Tim: Delete `bld` folder and run `pytask`
- [x] Janos: Delete `bld` folder and run `pytask`