### PR TITLE
Update plots

### DIFF
--- a/src/tranquilo_dev/config.py
+++ b/src/tranquilo_dev/config.py
@@ -87,7 +87,7 @@ class ProjectOptions(NamedTuple):
 # Set development options HERE and not in the class above
 # ======================================================================================
 OPTIONS = ProjectOptions(
-    PLOT_TYPES=("profile_plot",),
+    PLOT_TYPES=("profile_plot", "deviation_plot"),
     PROBLEM_SETS=("more_wild",),
 )
 

--- a/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
+++ b/src/tranquilo_dev/plotting/benchmark_plotting_functions.py
@@ -41,10 +41,10 @@ X_RANGE_UPDATES = {
     "profile_plot": {
         "publication": {
             "mw": {
-                "scalar_benchmark": (1, 50),
-                "ls_benchmark": (1, 40),
+                "scalar_benchmark": (1, 25),
+                "ls_benchmark": (1, 25),
                 "parallel_benchmark": (1, 6),
-                "noisy_benchmark": (1, 30),
+                "noisy_benchmark": (1, 25),
                 "scalar_vs_ls_benchmark": (1, 50),
             },
         },
@@ -250,16 +250,16 @@ LEGEND_LABEL_ORDER = {
             "SciPy-Nelder-Mead",
         ],
         "ls_benchmark": [
-            "Tranquilo-LS",
             "DFO-LS",
+            "Tranquilo-LS",
             "Pounders",
         ],
         "parallel_benchmark": [
-            "Tranquilo-LS",
             "Tranquilo-LS (2 cores)",
             "Tranquilo-LS (4 cores)",
             "Tranquilo-LS (8 cores)",
             "DFO-LS",
+            "Tranquilo-LS",
         ],
         "noisy_benchmark": [
             "DFO-LS (3 evals)",
@@ -268,8 +268,8 @@ LEGEND_LABEL_ORDER = {
             "Tranquilo-LS",
         ],
         "scalar_vs_ls_benchmark": [
-            "Tranquilo-LS",
             "DFO-LS",
+            "Tranquilo-LS",
             "Pounders",
             "Tranquilo-Scalar",
             "NlOpt-BOBYQA",
@@ -341,7 +341,7 @@ def plot_benchmark(data, plot_type, benchmark):
         problem_name=problem_name,
         plot_name=plot_name,
     )
-    legend_label_order = LEGEND_LABEL_ORDER.get(benchmark, None)
+    legend_label_order = LEGEND_LABEL_ORDER[dev_or_pub].get(plot_name, None)
 
     # Update label names
     data = {LABELS[name]: line for name, line in data.items()}

--- a/src/tranquilo_dev/plotting/illustrations.py
+++ b/src/tranquilo_dev/plotting/illustrations.py
@@ -10,6 +10,10 @@ from tranquilo.visualize import _get_sample_points
 
 
 def create_noise_plots():
+
+    HEIGHT = 500
+    WIDTH = 600
+
     out = []
 
     def func(x):
@@ -35,7 +39,9 @@ def create_noise_plots():
         )
     )
     fig.update_layout(layout)
-    fig.update_layout(height=500, width=600, template="plotly_white", showlegend=True)
+    fig.update_layout(
+        height=HEIGHT, width=WIDTH, template="plotly_white", showlegend=True
+    )
     fig.update_yaxes(
         showgrid=False,
         showline=True,
@@ -125,7 +131,7 @@ def create_noise_plots():
         )
         for x in trustregion:
             fig2.add_vline(x=x, line_color="grey", line_width=1)
-        fig2.update_layout(width=600)
+        fig2.update_layout(width=WIDTH)
 
         plotting_data.append(fig2.data)
         out.append(fig2)  # fig2.write_image(f'noise_plot_{i+2}.svg')
@@ -138,7 +144,7 @@ def create_noise_plots():
     fig3.update_layout(
         legend={"yanchor": "bottom", "y": -0.2, "xanchor": "center", "x": 0.5}
     )
-    fig3.update_layout(height=700, width=800, template="plotly_white")
+    fig3.update_layout(height=HEIGHT, width=1.8 * WIDTH, template="plotly_white")
     fig3.update_yaxes(
         showgrid=False,
         showline=True,
@@ -154,6 +160,11 @@ def create_noise_plots():
         zeroline=False,
     )
     out.append(fig3)
+
+    # Remove axis titles for all plots
+    out = [fig.update_layout(yaxis_title="", xaxis_title="") for fig in out]
+    # Remove legend
+    out = [fig.update_layout(showlegend=False) for fig in out]
     return out
 
 

--- a/src/tranquilo_dev/plotting/illustrations.py
+++ b/src/tranquilo_dev/plotting/illustrations.py
@@ -7,6 +7,8 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from tranquilo.visualize import _clean_legend_duplicates
 from tranquilo.visualize import _get_sample_points
+from tranquilo_dev.plotting.benchmark_plotting_functions import DARK_GRAY
+from tranquilo_dev.plotting.benchmark_plotting_functions import TABLEAU_10_COLORS
 
 
 def create_noise_plots():
@@ -28,6 +30,7 @@ def create_noise_plots():
     noise_x_grid = np.linspace(-2, 1.5, 40)
     noise_y = rng.normal(loc=func(noise_x_grid), scale=1.5)
     fig = px.line(x=x_grid, y=y)
+    fig.update_traces(line_color=TABLEAU_10_COLORS["blue"])
     fig.data[0].name = "criterion function"
     fig.data[0].showlegend = True
     layout = go.Layout(
@@ -39,21 +42,19 @@ def create_noise_plots():
         )
     )
     fig.update_layout(layout)
-    fig.update_layout(
-        height=HEIGHT, width=WIDTH, template="plotly_white", showlegend=True
-    )
+    fig.update_layout(height=HEIGHT, width=WIDTH, template="plotly_white")
     fig.update_yaxes(
         showgrid=False,
         showline=True,
         linewidth=1,
-        linecolor="black",
+        linecolor=DARK_GRAY,
         zeroline=False,
     )
     fig.update_xaxes(
         showgrid=False,
         showline=True,
         linewidth=1,
-        linecolor="black",
+        linecolor=DARK_GRAY,
         zeroline=False,
     )
     fig.update_layout(
@@ -74,7 +75,7 @@ def create_noise_plots():
             x=noise_x_grid,
             y=noise_y,
             mode="markers",
-            marker_color="rgb(0,0,255)",
+            marker_color=TABLEAU_10_COLORS["blue"],
             opacity=0.3,
             showlegend=False,
         )
@@ -106,18 +107,9 @@ def create_noise_plots():
                 x=xs,
                 y=ys,
                 mode="markers",
-                marker_color="rgb(0,0,255)",
+                marker_color=TABLEAU_10_COLORS["blue"],
                 showlegend=False,
                 opacity=0.3,
-            )
-        )
-        fig2.add_trace(
-            go.Scatter(
-                x=sample_xs,
-                y=sample_ys,
-                mode="markers",
-                marker_color="rgb(0,0,255)",
-                showlegend=False,
             )
         )
         fig2.add_trace(
@@ -126,11 +118,20 @@ def create_noise_plots():
                 y=model_ys,
                 mode="lines",
                 name="model",
-                line_color="#F98900",
+                line_color=TABLEAU_10_COLORS["orange"],
+            )
+        )
+        fig2.add_trace(
+            go.Scatter(
+                x=sample_xs,
+                y=sample_ys,
+                mode="markers",
+                marker_color=TABLEAU_10_COLORS["blue-35"],
+                showlegend=False,
             )
         )
         for x in trustregion:
-            fig2.add_vline(x=x, line_color="grey", line_width=1)
+            fig2.add_vline(x=x, line_color=DARK_GRAY, line_width=1)
         fig2.update_layout(width=WIDTH)
 
         plotting_data.append(fig2.data)
@@ -149,14 +150,14 @@ def create_noise_plots():
         showgrid=False,
         showline=True,
         linewidth=1,
-        linecolor="black",
+        linecolor=DARK_GRAY,
         zeroline=False,
     )
     fig3.update_xaxes(
         showgrid=False,
         showline=True,
         linewidth=1,
-        linecolor="black",
+        linecolor=DARK_GRAY,
         zeroline=False,
     )
     out.append(fig3)
@@ -165,6 +166,8 @@ def create_noise_plots():
     out = [fig.update_layout(yaxis_title="", xaxis_title="") for fig in out]
     # Remove legend
     out = [fig.update_layout(showlegend=False) for fig in out]
+    # Set y axis limits
+    out = [fig.update_layout(yaxis_range=[-5, 25]) for fig in out]
     return out
 
 

--- a/src/tranquilo_dev/plotting/task_create_presentation_illustrations.py
+++ b/src/tranquilo_dev/plotting/task_create_presentation_illustrations.py
@@ -1,17 +1,29 @@
+import plotly.io as pio
 import pytask
 from tranquilo_dev.config import BLD
 from tranquilo_dev.plotting.illustrations import create_noise_plots
 from tranquilo_dev.plotting.illustrations import create_other_illustration_plots
 
+pio.kaleido.scope.mathjax = None
+
+
 BLD_SLIDEV = BLD.joinpath("bld_slidev")
+BLD_PAPER = BLD.joinpath("bld_paper")
 
 NOISE_PLOT_NAMES = [f"noise_plot_{k}.svg" for k in range(5)]
 
+NOISE_PLOT_PRODUCES = []
+for folder, suffix in ((BLD_SLIDEV, ".svg"), (BLD_PAPER / "illustrations", ".pdf")):
+    for name in NOISE_PLOT_NAMES:
+        NOISE_PLOT_PRODUCES.append(folder.joinpath(f"{name}").with_suffix(suffix))
 
-@pytask.mark.produces([BLD_SLIDEV.joinpath(name) for name in NOISE_PLOT_NAMES])
+
+@pytask.mark.produces(NOISE_PLOT_PRODUCES)
 def task_create_noise_plots(produces):
     figures = create_noise_plots()
-    for path, fig in zip(produces.values(), figures):
+    # loop over (*figures, *figures) to write the same figure twice for svg and pdf
+    for path, fig in zip(produces.values(), (*figures, *figures)):
+        pio.full_figure_for_development(fig, warn=False)
         fig.write_image(path)
 
 

--- a/src/tranquilo_dev/plotting/task_plot_optimal_samples.py
+++ b/src/tranquilo_dev/plotting/task_plot_optimal_samples.py
@@ -21,7 +21,7 @@ COLORS = {
     "gray": "#b8b0ac",
 }
 
-PRODUCT = BLD / "bld_paper" / "optimal_sphere_samples.pdf"
+PRODUCT = BLD / "bld_paper" / "illustrations" / "optimal_sphere_samples.pdf"
 
 
 @pytask.mark.produces(PRODUCT)


### PR DESCRIPTION
In this PR, I updated the benchmark and illustration plots.

More specifically, I
- Change the illustrations colors and remove labels and legend
- Fix a bug in the label ordering of the benchmark plots
- Save illustrations in pdf format to `bld_paper`

> [!CAUTION]
> ### Final Checks:
> - [x] Delete the `bld` folder and run `pytask`
